### PR TITLE
Add Jupyter to the requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 sklearn
 pandas
 scipy
+jupyter


### PR DESCRIPTION
- Increase kernel management compatibility and avoid potential bugs when using VENV 
- 03 module ```import nilearn``` may fail if  Jupyter notebook was launched using system main Anaconda Python binary while requirements were installed in separate environment. 
- Being more explicit here will ensure better user experience prevent bugs when using separately managed python environment.